### PR TITLE
Update :project_tag location in readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,7 @@ The yml file needs to look something like this:
   
 ```ruby
 :cloud_providers: ['AWS', 'Brightbox']
+:project_tag: "YOUR APP NAME"
 
 :AWS:
   :aws_access_key_id: "YOUR ACCESS KEY"
@@ -168,7 +169,6 @@ The yml file needs to look something like this:
   :params:
     :region: 'eu-west-1'
   :load_balanced: true
-  :project_tag: "YOUR APP NAME"
   
 :Brightbox:
   :brightbox_client_id: "YOUR CLIENT ID"


### PR DESCRIPTION
I could see it being useful to have a per-provider project_tag, but this would require some code refactoring, so I think this minor update to the docs should be good for now.

I've tested this on an ec2 cluster, and it works as specified.
